### PR TITLE
Add editor nicities

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.pyc
 *.swp
 .vagrant
-.vscode
 .DS_Store
 staticfiles
 .env

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["EditorConfig.EditorConfig", "ms-python.python"]
+}


### PR DESCRIPTION
Add an `.editorconfig` and `.vscode` folder with an `extensions.json` file to meow. The `.editorconfig` files is to ensure style consistency, the `extensions.json` is so we don't have to keep telling people which extensions to download.